### PR TITLE
Set certain values for each invoice, not every invoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use this yourself, fork and clone, then follow these instructions:
   $ cp _config.yml.example _config.yml
   ```
 
-  Edit your `_config.yml` file. Edit and add as many `invoice_line_items` as you like.
+  Edit your `_config.yml` file. Edit and add as many `invoice_line_items` as you like. The `invoice_currency`, `invoice_line_items`, and `invoice_payment_info` values are set for each invoice, so you can change them in future without old invoices being affected.
 
 3. Run the app:
 

--- a/_config.yml.example
+++ b/_config.yml.example
@@ -5,7 +5,7 @@ person_title: Hubbernaut
 person_email: username@github.com
 person_website: http://example.com
 person_github: https://github.com/username
-person_currency: EUR
+invoice_currency: EUR
 invoice_line_items:
   - title: Monthly Salary
     value: 100.00
@@ -13,7 +13,7 @@ invoice_line_items:
     value: 10.00
   - title: Cell Phone Reimbursement
     value: 1.00
-person_payment_info: |
+invoice_payment_info: |
   __Account Name:__ Your name \\
   __SWIFT Code:__ blah \\
   __Something else:__ blah

--- a/invoice-template.md
+++ b/invoice-template.md
@@ -13,10 +13,10 @@ __For period:__ {{ page.period }}
 
 {% assign total = 0 %}
 |__Description__|__Amount__|
-|--|--:|{% for item in site.invoice_line_items %}{% assign total = total | plus:item.value %}
-|{{item.title}}|{{item.value}} {{site.invoice_currency}}|{% endfor %}
-|__Total:__|{{total}} {{site.invoice_currency}}|
+|--|--:|{% for item in page.invoice_line_items %}{% assign total = total | plus:item.value %}
+|{{item.title}}|{{item.value}} {{page.invoice_currency}}|{% endfor %}
+|__Total:__|{{total}} {{page.invoice_currency}}|
 
 ## Bank/Wire Information
 
-{{site.invoice_payment_info}}
+{{page.invoice_payment_info}}

--- a/invoice-template.md
+++ b/invoice-template.md
@@ -14,9 +14,9 @@ __For period:__ {{ page.period }}
 {% assign total = 0 %}
 |__Description__|__Amount__|
 |--|--:|{% for item in site.invoice_line_items %}{% assign total = total | plus:item.value %}
-|{{item.title}}|{{item.value}} {{site.person_currency}}|{% endfor %}
-|__Total:__|{{total}} {{site.person_currency}}|
+|{{item.title}}|{{item.value}} {{site.invoice_currency}}|{% endfor %}
+|__Total:__|{{total}} {{site.invoice_currency}}|
 
 ## Bank/Wire Information
 
-{{site.person_payment_info}}
+{{site.invoice_payment_info}}

--- a/script/invoice
+++ b/script/invoice
@@ -3,6 +3,7 @@
 require "date"
 require "fileutils"
 require "pdfkit"
+require "psych"
 
 gen_date = DateTime.now
 if ARGV.length == 1
@@ -21,14 +22,21 @@ unless File.directory?(pdfs_dir)
 end
 pdf_filename = File.join(pdfs_dir, last.strftime("%Y-%m-%d-invoice.pdf"))
 
+invoice_data = Psych.load_file(File.join(Dir.pwd, "_config.yml"))
+invoice_line_items = Psych.dump(invoice_data["invoice_line_items"], :indentation => 2).gsub "---\n", ""
+invoice_payment_info = Psych.dump(invoice_data["invoice_payment_info"], :indentation => 2).gsub "---", ""
 monthly_data =
 "---
-layout:         post
-title:          \"Invoice – #{last.strftime('%B, %Y')}\"
-date:           #{last.strftime('%Y-%m-%d 10:00:00')}
+layout: post
+title: \"Invoice – #{last.strftime('%B, %Y')}\"
+date: #{last.strftime('%Y-%m-%d 10:00:00')}
 invoice_number: \"#{last.strftime('%Y%m-GITHUB')}\"
-period:         \"#{last.strftime('%B, %Y')}\"
-pdf_url:        \"/pdfs/#{last.strftime("%Y-%m-%d-invoice.pdf")}\"
+period: \"#{last.strftime('%B, %Y')}\"
+pdf_url: \"/pdfs/#{last.strftime("%Y-%m-%d-invoice.pdf")}\"
+invoice_currency: #{invoice_data["invoice_currency"]}
+invoice_line_items:
+#{invoice_line_items}
+invoice_payment_info:#{invoice_payment_info}
 ---
 "
 


### PR DESCRIPTION
Updates `script/invoice` and the corresponding invoice template, so that the appropriate values are saved with each invoice, not re-generated each time the server is run.

This means that you can update `invoice_currency`, `invoice_line_items`, and `invoice_payment_info`, when one of these values changes, without this impacting your old invoices.
